### PR TITLE
fix(module) 'node-pre-gyp' module not found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const { find } = require('node-pre-gyp');
+const { find } = require('@discordjs/node-pre-gyp');
 const { resolve, join } = require('path');
 
 const bindingPath = find(resolve(join(__dirname, '..', 'package.json')));


### PR DESCRIPTION
In the package.json theres a '@discordjs/node-pre-gyp' but in the index.js it requires the 'node-pre-gyp', resulting in "Error: Cannot find module 'node-pre-gyp'". Changing the module in index.js fix the issue