### PR TITLE
fix(types): Fix typo in setBitrate method.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,12 +1,11 @@
 declare module '@discordjs/opus' {
 	export class OpusEncoder {
 		public constructor(rate: number, channels: number);
-		
 		public encode(buf: Buffer): Buffer;
 		public decode(buf: Buffer): Buffer;
 		public applyEncoderCTL(ctl: number, value: number): void;
 		public applyDecoderCTL(ctl: number, value: number): void;
-		public setBirate(bitrate: number): void;
+		public setBitrate(bitrate: number): void;
 		public getBitrate(): number;
 	}
 }


### PR DESCRIPTION
Fixes a typo in the type definitions. This is probably a big deal for typescript users.

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
