### PR TITLE
chore(readme): add macOS arm64 to platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ const decoded = encoder.decode(encoded);
 - Linux arm (RPi 1 & 2)
 - Linux arm64 (RPi 3)
 - macOS x64
+- macOS arm64
 - Windows x64


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds "macOS arm64" to the list of supported platforms in `README.md`. Support was added in https://github.com/discordjs/opus/pull/97 and released in v`0.6.0`.

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
