### PR TITLE
Add Node v17 prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, ubuntu-20.04, ubuntu-18.04, windows-2019]
-        node: [12, 13, 14, 15, 16]
+        node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       image: node:${{ matrix.node }}-alpine
     strategy:
       matrix:
-        node: [12, 13, 14, 15, 16]
+        node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-10.15, ubuntu-20.04, ubuntu-18.04, windows-2019]
-        node: [12, 13, 14, 15, 16]
+        node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       image: node:${{ matrix.node }}-alpine
     strategy:
       matrix:
-        node: [12, 13, 14, 15, 16]
+        node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This will add Node 17 prebuilds.
Currently, it seems releases only have prebuilds up to node v16.

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
