### PR TITLE
feat(ci): add prebuilt binaries for linux aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [published]
 jobs:
-  build:
-    name: Prebuild
+  build_x86_64:
+    name: Prebuild x86_64
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,8 +32,8 @@ jobs:
         with:
           path: "build/stage/**/*.tar.gz"
 
-  build_musl:
-    name: Prebuild (musl)
+  build_musl_x86_64:
+    name: Prebuild x86_64(musl)
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine
@@ -54,6 +54,78 @@ jobs:
 
       - name: Package prebuild
         run: npm run build
+
+      - name: Upload prebuild asset
+        uses: icrawl/action-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: "build/stage/**/*.tar.gz"
+
+          
+  build_aarch64:
+    name: Prebuild aarch64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+        node: [12, 13, 14, 15, 16]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node v${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm install --build-from-source
+
+      - name: Package prebuild
+        run: |
+          sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
+
+
+      - name: Upload prebuild asset
+        uses: icrawl/action-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: "build/stage/**/*.tar.gz"
+
+  build_musl_aarch64:
+    name: Prebuild aarch64(musl)
+    runs-on: ubuntu-latest
+    container:
+      image: node:${{ matrix.node }}-alpine
+    strategy:
+      matrix:
+        node: [12, 13, 14, 15, 16]
+    steps:
+      - name: Setup env with Node v${{ matrix.node }}
+        run: |
+          apk add --update
+          apk add --no-cache ca-certificates git curl build-base python3 g++ make
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup musl cross compoiler
+        run: |
+          curl -OL https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar -xzvf aarch64-linux-musl-cross.tgz
+          $(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc --version
+
+      - name: Install dependencies
+        run: npm install --unsafe-perm --build-from-source
+
+      - name: Package prebuild
+        run: |
+          CC=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc \
+          CXX=$(pwd)/aarch64-linux-musl-cross/bin/aarch64-linux-musl-g++ \
+          npx node-pre-gyp --target_arch=arm64 configure build package
 
       - name: Upload prebuild asset
         uses: icrawl/action-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
           sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
-
       - name: Upload prebuild asset
         uses: icrawl/action-artifact@v2
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup musl cross compoiler
+      - name: Setup musl cross compiler
         run: |
           curl -OL https://musl.cc/aarch64-linux-musl-cross.tgz
           tar -xzvf aarch64-linux-musl-cross.tgz


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds prebuilt binaries for arm64 Linux. 
With prebuilt binaries, installation of a project with `@discordjs/opus` in its dependency will be faster.

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
