### PR TITLE
doc(types): Add JSDoc to decode method

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,6 +2,10 @@ declare module '@discordjs/opus' {
 	export class OpusEncoder {
 		public constructor(rate: number, channels: number);
 		public encode(buf: Buffer): Buffer;
+		/**
+		 * Decodes the given Opus buffer to PCM signed 16-bit little-endian
+		 * @param buf Opus buffer
+		 */
 		public decode(buf: Buffer): Buffer;
 		public applyEncoderCTL(ctl: number, value: number): void;
 		public applyDecoderCTL(ctl: number, value: number): void;


### PR DESCRIPTION
Closes #136

**Please describe the changes this PR makes and why it should be merged:**
Adds some JSDoc to the `decode` method, to make it clear which format is being returned.
**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.

Signed-off-by: Klaus Striessnig <k.striessnig@gmail.com>