### PR TITLE
feat(opus): add `adjustBitrate` function

### DIFF
--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -35,6 +35,7 @@ Object OpusEncoder::Init(Napi::Env env, Object exports) {
 		InstanceMethod("applyDecoderCTL", &OpusEncoder::ApplyDecoderCTL),
 		InstanceMethod("setBitrate", &OpusEncoder::SetBitrate),
 		InstanceMethod("getBitrate", &OpusEncoder::GetBitrate),
+		InstanceMethod("adjustBitrate", &OpusEncoder::AdjustBitrate),
 	});
 
 	exports.Set("OpusEncoder", func);
@@ -204,6 +205,16 @@ Napi::Value OpusEncoder::GetBitrate(const CallbackInfo& args) {
 	opus_encoder_ctl(this->encoder, OPUS_GET_BITRATE(&bitrate));
 
 	return Napi::Number::New(env, bitrate);
+}
+
+void OpusEncoder::AdjustBitrate(const CallbackInfo& args) {
+    Napi::Env env = args.Env();
+    int targetBitrate = args[0].As<Napi::Number>().Int32Value();
+    int error = opus_encoder_ctl(this->encoder, OPUS_SET_BITRATE(targetBitrate));
+    if (error != OPUS_OK) {
+        Napi::Error::New(env, std::string("Error adjusting bitrate: ") + opus_strerror(error)).ThrowAsJavaScriptException();
+		return;
+    }
 }
 
 Object Init(Napi::Env env, Object exports) {

--- a/src/node-opus.h
+++ b/src/node-opus.h
@@ -38,6 +38,8 @@ class OpusEncoder : public ObjectWrap<OpusEncoder> {
 		void ApplyDecoderCTL(const CallbackInfo& args);
 		
 		void SetBitrate(const CallbackInfo& args);
-		
+
+		void AdjustBitrate(const CallbackInfo& args);
+
 		Napi::Value GetBitrate(const CallbackInfo& args);
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,5 +7,6 @@ declare module '@discordjs/opus' {
 		public applyDecoderCTL(ctl: number, value: number): void;
 		public setBitrate(bitrate: number): void;
 		public getBitrate(): number;
+		public adjustBitrate(bitrate: number): void;
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Semantic versioning classification:**

`OpusEncoder::SetBitrate` is a function that sets the bitrate of the encoder to a specific value that is passed as an argument. It directly sets the bitrate to the provided value, regardless of the current bitrate of the encoder.

On the other hand, `OpusEncoder::AdjustBitrate` is a function that adjusts the current bitrate of the encoder by a certain value that is passed as an argument. It does not set the bitrate to a specific value, but rather it increases or decreases the current bitrate by a certain amount.

For example, if the current bitrate of the encoder is 64kbps and you call `OpusEncoder::AdjustBitrate(32000)`, the new bitrate will be 96kbps (64kbps + 32kbps).

This function is more flexible than `OpusEncoder::SetBitrate`, it allows you to adjust the bitrate by a certain amount.

for a clear explanation, The main difference between the `OpusEncoder::AdjustBitrate` and `OpusEncoder::SetBitrate` methods is that `OpusEncoder::SetBitrate` is typically used to set the bitrate of the encoder before the encoding process begins, whereas `OpusEncoder::AdjustBitrate` is used to change the bitrate of the encoder during the encoding process.

The `OpusEncoder::SetBitrate` method is used to set the bitrate of the encoder to a specific value before the encoding process begins. It takes an integer argument representing the target bitrate in bits per second, and it uses the Opus codec library's OPUS_SET_BITRATE control command to set the bitrate of the encoder.

- [x] This PR changes the library's interface (methods or parameters added)
