### PR TITLE
ci: fix build/release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,11 +105,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
-
       - name: Install dependencies
         run: npm install --build-from-source
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Update npm
-        run: |
-          npm i -g npm@latest
-
       - name: Install dependencies
         run: npm install --build-from-source
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Package prebuild
         run: |
-          sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt update -y && sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
   build_aarch64_node_ge_18:
@@ -135,7 +135,7 @@ jobs:
 
       - name: Package prebuild
         run: |
-          sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt update -y && sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
   build_musl_aarch64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
       - name: Install dependencies
         run: npm install --build-from-source
 
@@ -95,6 +100,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
 
       - name: Install dependencies
         run: npm install --build-from-source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Install setuptools
+        run: |
+          python3 -m pip install setuptools
+
       - name: Install dependencies
         run: npm install --build-from-source
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [12, 13, 14, 15, 16, 17]
+        node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [18, 19, 20, 21]
+        node: [18, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -54,9 +54,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Install setuptools
+      - name: Update npm
         run: |
-          python3 -m pip install setuptools
+          npm i -g npm@latest
 
       - name: Install dependencies
         run: npm install --build-from-source
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [12, 13, 14, 15, 16, 17]
+        node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [18, 19, 20, 21]
+        node: [18, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
     branches:
       - '**'
 jobs:
-  build_x86_64:
-    name: Build x86_64
+  build_x86_64_legacy_nodejs:
+    name: Build x86_64 (legacy Node.js)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -37,8 +37,8 @@ jobs:
       - name: Package prebuild
         run: npm run build
 
-  build_x86_64_node_ge_18:
-    name: Build x86_64 node >= 18
+  build_x86_64:
+    name: Build x86_64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -65,7 +65,7 @@ jobs:
         run: npm run build
 
   build_musl_x86_64:
-    name: Build x86_64(musl)
+    name: Build x86_64 (musl)
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine
@@ -88,8 +88,8 @@ jobs:
       - name: Package prebuild
         run: npm run build
 
-  build_aarch64:
-    name: Prebuild aarch64
+  build_aarch64_legacy_nodejs:
+    name: Prebuild aarch64 (legacy Node.js)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -113,8 +113,8 @@ jobs:
           sudo apt update -y && sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
-  build_aarch64_node_ge_18:
-    name: Prebuild aarch64 node >= 18
+  build_aarch64:
+    name: Prebuild aarch64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -139,7 +139,7 @@ jobs:
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
   build_musl_aarch64:
-    name: Prebuild aarch64(musl)
+    name: Prebuild aarch64 (musl)
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [18, 19]
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [18, 19]
+        node: [18, 19, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [18, 19]
+        node: [18, 19, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [18, 19]
     steps:
       - name: Checkout repository
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 13, 14, 15, 16, 17, 18, 19]
+        node: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 13, 14, 15, 16, 17, 18, 19]
+        node: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [18, 19]
+        node: [18, 19, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [18, 19]
+        node: [18, 19, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 13, 14, 15, 16, 17, 18, 19]
+        node: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 13, 14, 15, 16, 17, 18, 19]
+        node: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
     steps:
       - name: Setup env with Node v${{ matrix.node }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [12, 13, 14, 15, 16, 17]
+        node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
-        node: [18, 19, 20, 21]
+        node: [18, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -55,9 +55,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Install setuptools
+      - name: Update npm
         run: |
-          python3 -m pip install setuptools
+          npm i -g npm@latest
 
       - name: Install dependencies
         run: npm install --build-from-source
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [12, 13, 14, 15, 16, 17]
+        node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        node: [18, 19, 20, 21]
+        node: [18, 20, 21]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Package prebuild
         run: |
-          sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt update -y && sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
       - name: Upload prebuild asset
@@ -157,7 +157,7 @@ jobs:
 
       - name: Package prebuild
         run: |
-          sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt update -y && sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ npx node-pre-gyp --target_arch=arm64 configure build package
 
       - name: Upload prebuild asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [published]
 jobs:
-  build_x86_64:
-    name: Prebuild x86_64
+  build_x86_64_legacy_nodejs:
+    name: Prebuild x86_64 (legacy Node.js)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -38,8 +38,8 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
-  build_x86_64_node_ge_18:
-    name: Build x86_64 node >= 18
+  build_x86_64:
+    name: Prebuild x86_64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -73,7 +73,7 @@ jobs:
           path: 'build/stage/**/*.tar.gz'
 
   build_musl_x86_64:
-    name: Prebuild x86_64(musl)
+    name: Prebuild x86_64 (musl)
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine
@@ -103,8 +103,8 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
-  build_aarch64:
-    name: Prebuild aarch64
+  build_aarch64_legacy_nodejs:
+    name: Prebuild aarch64 (legacy Node.js)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -135,8 +135,8 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
-  build_aarch64_node_ge_18:
-    name: Prebuild aarch64 node >= 18
+  build_aarch64:
+    name: Prebuild aarch64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -168,7 +168,7 @@ jobs:
           path: 'build/stage/**/*.tar.gz'
 
   build_musl_aarch64:
-    name: Prebuild aarch64(musl)
+    name: Prebuild aarch64 (musl)
     runs-on: ubuntu-latest
     container:
       image: node:${{ matrix.node }}-alpine

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [18, 19]
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
       - name: Install dependencies
         run: npm install --build-from-source
 
@@ -49,6 +54,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Install setuptools
+        run: |
+          python3 -m pip install setuptools
 
       - name: Install dependencies
         run: npm install --build-from-source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-11, macos-12, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [18, 19]
     steps:
       - name: Checkout repository
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         node: [12, 13, 14, 15, 16, 17]
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Update npm
-        run: |
-          npm i -g npm@latest
-
       - name: Install dependencies
         run: npm install --build-from-source
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ref: nodejs/node-gyp#2219
ref: nodejs/node-gyp#2869

This PR includes following changes:
- Fix python version to 3.8 in node <=17 and 19 (nodejs/node-gyp#2219)
- Remove macos-10.15 and ubuntu-18.04 runner ([They are no longer supported](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources))
- Add `apt update` before `apt install`
- Add macos-13 runner
- Add node.js 20 and 21

Current workflow does not succeed due to updates to python 3.12 in github runners.

> Fix python version to 3.8 in node <=17 and 19

Downgrading to python 3.8 is necessary in older node.js, because nodejs/node-gyp#2219 was fixed in gyp-next v0.7.0/node-gyp v0.8.0, which is not included in older node.js.

> Remove macos-10.15 and ubuntu-18.04 runner

Also, macos-10.15 and ubuntu-18.04 runner job never starts, so I suggest removing them.

> Add `apt update` before `apt install`

The `Failed to fetch 404 not found` error had occured because of this, and this PR also fixes that.

> Add macos-13 runner
> Add node.js 20 and 21

Finally, I added macos-13 runner and node.js 20/21, because I think it is better to run test for these environment and provide prebuild.
However, if you feel these should be in another PR and discussed separately, I am willing to remove them.

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
