### PR TITLE
fix: add cflag to fix build on gcc 14

### DIFF
--- a/deps/binding.gyp
+++ b/deps/binding.gyp
@@ -193,6 +193,7 @@
                 "-Wno-unused-parameter",
                 "-Wno-sign-compare",
                 "-Wno-maybe-uninitialized",
+                "-Wno-incompatible-pointer-types",
             ],
             "include_dirs": [
                 "config/opus/<(OS)/<(target_arch)",


### PR DESCRIPTION
<!-- Please describe the changes this pull request makes and why it should be merged. -->

This PR addresses a node-gyp build error when using GCC 14 by adding a cflag to ignore that error type. 

This error only occurs when there is no prebuilt for the node release  that the user has installed.

GCC 14 changed incompatible-pointer-types to be an error instead of a warning https://gcc.gnu.org/gcc-14/porting_to.html. This causes the node-gyp build to fail on newer linux distros. 

- [x] Code changes have been tested, or there are no code changes
