### PR TITLE
add "opus/silk/arm/NSQ_neon.c" to the "target_arch==\"arm64\"" condit…

### DIFF
--- a/deps/binding.gyp
+++ b/deps/binding.gyp
@@ -213,6 +213,7 @@
                             "opus/celt/arm/celt_neon_intr.c",
                             "opus/celt/arm/pitch_neon_intr.c",
                             "opus/silk/arm/LPC_inv_pred_gain_neon_intr.c",
+                            "opus/silk/arm/NSQ_neon.c"
                         ],
                         "include_dirs": [
                             "opus",

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,5 +9,9 @@ const frame = fs.readFileSync(path.join(__dirname, 'frame.opus'));
 
 const decoded = opus.decode(frame);
 
+const reEncoded = opus.encode(decoded);
+
 assert(decoded.length === 640, 'Decoded frame length is not 640');
+assert(reEncoded.length === 45, 're encoded frame length is not 45');
+
 console.log('Passed');


### PR DESCRIPTION
## Description

<!-- Please describe the changes this pull request makes and why it should be merged. -->

Fixes `dyld: missing symbol called` on macOS and apple silicon 
as reported in #165 