### PR TITLE
chore: cleanup matrices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2022]
         node: [18, 20, 21, 22]
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2022]
         node: [18, 20, 21, 22]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

- Removes macos-12 (deprecated) and windows-2019 for newer node versions (double windows versions don't work)

- [ ] Code changes have been tested, or there are no code changes
