### PR TITLE
ci: add builds on ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2022]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022]
         node: [18, 20, 21, 22]
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2019]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2019]
         node: [12, 13, 14, 15, 16, 17, 19]
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-20.04, ubuntu-22.04, windows-2022]
+        os: [macos-13, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022]
         node: [18, 20, 21, 22]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

This adds builds and releases using the `ubuntu-24.04` runners as well as the other existing ones.

- [x] Code changes have been tested, or there are no code changes
