### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,24 +16,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-13,
           macos-14,
           macos-15,
           ubuntu-22.04,
           ubuntu-22.04-arm,
           ubuntu-24.04,
           ubuntu-24.04-arm,
-          windows-2022
+          windows-2022,
+          windows-2025
         ]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24, 25]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Install Node v${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 
@@ -50,10 +50,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24, 25]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
         os: [
           macos-14,
           macos-15,
+          macos-26,
           ubuntu-22.04,
           ubuntu-22.04-arm,
           ubuntu-24.04,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
         os: [
           macos-14,
           macos-15,
+          macos-26,
           ubuntu-22.04,
           ubuntu-22.04-arm,
           ubuntu-24.04,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          macos-13,
           macos-14,
           macos-15,
           ubuntu-22.04,
           ubuntu-22.04-arm,
           ubuntu-24.04,
           ubuntu-24.04-arm,
-          windows-2022
+          windows-2022,
+          windows-2025
         ]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24, 25]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Install Node v${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 
@@ -51,10 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        node: [18, 20, 22, 24]
+        node: [20, 22, 24, 25]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
 


### PR DESCRIPTION
The macos-13 runner image has been retired:
- https://github.com/actions/runner-images/issues/13046

Added windows-2025 and macos-26 (which is in beta, but should be fine?):
- https://github.com/actions/runner-images?tab=readme-ov-file#available-images

Updated the node.js versions to the ones that are still supported:
- https://github.com/nodejs/release#release-schedule