### PR TITLE
refactor!: bump minimum node version to v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # @discordjs/opus [![Build](https://github.com/discordjs/opus/workflows/Build/badge.svg)](https://github.com/discordjs/opus/actions?query=workflow%3ABuild) [![Prebuild](https://github.com/discordjs/opus/workflows/Prebuild/badge.svg)](https://github.com/discordjs/opus/actions?query=workflow%3APrebuild)
 
-> Native bindings to libopus v1.3
+> Native bindings to libopus v1.5
 
 ## Usage
 
 ```js
-const { OpusEncoder } = require('@discordjs/opus');
+import { OpusEncoder } from '@discordjs/opus';
 
 // Create the encoder.
 // Specify 48kHz sampling rate and 2 channel size.
-const encoder = new OpusEncoder(48000, 2);
+const encoder = new OpusEncoder(48_000, 2);
 
 // Encode and decode.
 const encoded = encoder.encode(buffer);
@@ -18,7 +18,7 @@ const decoded = encoder.decode(encoded);
 
 ## Platform support
 
-⚠ Node.js 18.0.0 or newer is required.
+⚠ Node.js v20 or newer is required.
 
 - Linux x64 & ia32
 - Linux arm (RPi 1 & 2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"typescript": "~5.9.3"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20"
 			}
 		},
 		"node_modules/@angular-eslint/bundled-angular-compiler": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"eslint-plugin-vue": "npm:@favware/skip-dependency@latest"
 	},
 	"engines": {
-		"node": ">=18.0.0"
+		"node": ">=20"
 	},
 	"binary": {
 		"module_name": "opus",


### PR DESCRIPTION
BREAKING CHANGE: The minimum supported Node.js version is now v20.