### PR TITLE
feat(OpusEncoder): add opus_decode/encode_float binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ const encoder = new OpusEncoder(48_000, 2);
 // Encode and decode.
 const encoded = encoder.encode(buffer);
 const decoded = encoder.decode(encoded);
+
+// Encode and decode in float32.
+const encodedFP = encoder.encodeFloat(buffer);
+const decodedFP = encoder.decodeFloat(encodedFP);
 ```
 
 ## Platform support

--- a/src/node-opus.h
+++ b/src/node-opus.h
@@ -16,6 +16,7 @@ class NodeOpusEncoder : public ObjectWrap<NodeOpusEncoder> {
 
 		unsigned char outOpus[MAX_PACKET_SIZE];
 		opus_int16* outPcm;
+		float* outFloat;
 
 	protected:
 		int EnsureEncoder();
@@ -32,6 +33,8 @@ class NodeOpusEncoder : public ObjectWrap<NodeOpusEncoder> {
 		Napi::Value Encode(const CallbackInfo& args);
 		
 		Napi::Value Decode(const CallbackInfo& args);
+
+		Napi::Value DecodeFloat(const CallbackInfo& args);
 		
 		void ApplyEncoderCTL(const CallbackInfo& args);
 		

--- a/src/node-opus.h
+++ b/src/node-opus.h
@@ -31,6 +31,8 @@ class NodeOpusEncoder : public ObjectWrap<NodeOpusEncoder> {
 		~NodeOpusEncoder();
 
 		Napi::Value Encode(const CallbackInfo& args);
+
+		Napi::Value EncodeFloat(const CallbackInfo& args);
 		
 		Napi::Value Decode(const CallbackInfo& args);
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -15,6 +15,15 @@ const { OpusEncoder } = require('../lib/index.js');
   
   assert(decoded.length === 640, 'Decoded frame length is not 640');
   assert(reEncoded.length === 45, 're-encoded frame length is not 45');
+
+  const decodedFloat = opus.decodeFloat(frame);
+  
+  const reEncodedFloat = opus.encodeFloat(decodedFloat);
+  
+  // float32 buffer should be 2x the size of int16 buffer
+  assert(decodedFloat.length === 1280, 'Decoded float frame length is not 1280');
+  // Encoded size differs slightly due to precision differences
+  assert(reEncodedFloat.length === 43, 're-encoded float frame length is not 43');
 }
 
 // Default values work


### PR DESCRIPTION
Closes #171 

## Description
This PR adds bindings for `opus_decode_float` and `opus_encode_float` to support floating-point operations.

- [x] Code changes have been tested, or there are no code changes