### PR TITLE
Add Bun runtime support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,37 @@ jobs:
       - name: Package prebuild
         run: npm run build
 
+  bun:
+    name: Bun build and test on ubuntu
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Node v24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+
+      - name: Run native install
+        run: bun run install
+
+      - name: Build prebuild
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test
+
   build_musl:
     name: Build node ${{ matrix.node }} on ${{ matrix.os }} (musl)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         run: bun run build
 
       - name: Run tests
-        run: bun run test
+        run: bun run test:bun
 
   build_musl:
     name: Build node ${{ matrix.node }} on ${{ matrix.os }} (musl)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: bun run build
 
       - name: Run tests
-        run: bun run test
+        run: bun run test:bun
 
   build_musl:
     name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (musl)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,13 @@ jobs:
       - name: Run tests
         run: bun run test:bun
 
+      - name: Upload prebuild asset
+        uses: icrawl/action-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: 'build/stage/**/*.tar.gz'
+
   build_musl:
     name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (musl)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,45 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
+  build_debian:
+    name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (debian)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        node: [20, 22]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup container
+        run: |
+          docker run --name runner --rm -it -d -v $PWD:/node-opus -w /node-opus node:${{ matrix.node }}-bullseye
+
+      - name: Setup env with Node v${{ matrix.node }}
+        run: |
+          docker exec runner apt-get update
+          docker exec runner apt-get install -y ca-certificates git curl build-essential python3 g++ make libopus-dev
+
+      - name: Install dependencies
+        run: docker exec runner npm install --build-from-source
+
+      - name: Package prebuild
+        run: docker exec runner npm run build
+
+      - name: Stop container
+        run: docker rm -f runner
+
+      - name: Upload prebuild asset
+        uses: icrawl/action-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: 'build/stage/**/*.tar.gz'
+
   build_musl:
     name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (musl)
     runs-on: ${{ matrix.os }}
@@ -90,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        node: [20, 22, 24, 25]
+        node: [20, 22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,37 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
+  bun:
+    name: Bun build and test on ubuntu
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Node v24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+
+      - name: Run native install
+        run: bun run install
+
+      - name: Build prebuild
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test
+
   build_musl:
     name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (musl)
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,25 @@ const decoded = encoder.decode(encoded);
 - macOS x64
 - macOS arm64
 - Windows x64
+
+## Bun support
+
+Bun does not run lifecycle scripts by default. You can either trust this dependency or run the install script manually. Bun uses the Node 20 N-API prebuilds by default:
+
+```bash
+bun pm trust @discordjs/opus
+bun install
+```
+
+```bash
+bun install --ignore-scripts
+bun run install
+```
+
+If you use a monorepo, run the command in the workspace that installs `@discordjs/opus`.
+
+To run the test suite with Bun, use:
+
+```bash
+bun run test
+```

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ If you use a monorepo, run the command in the workspace that installs `@discordj
 To run the test suite with Bun, use:
 
 ```bash
-bun run test
+bun run test:bun
 ```

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
 	"author": "iCrawl <icrawltogo@gmail.com>",
 	"license": "MIT",
 	"scripts": {
-		"install": "node-pre-gyp install --fallback-to-build",
-		"build": "node-pre-gyp install build package",
+		"install": "bun x node-pre-gyp install --fallback-to-build || node-pre-gyp install --fallback-to-build",
+		"build": "bun x node-pre-gyp install build package || node-pre-gyp install build package",
 		"lint": "prettier --check . && eslint lib --format=pretty",
 		"lint:fix": "prettier --write . && eslint lib --fix --format=pretty",
-		"test": "node tests/test.js"
+		"test": "bun tests/test.js || node tests/test.js"
 	},
 	"keywords": [
 		"native",
@@ -51,9 +51,9 @@
 	},
 	"binary": {
 		"module_name": "opus",
-		"module_path": "./prebuild/{node_abi}-napi-v{napi_build_version}-{platform}-{arch}-{libc}-{libc_version}/",
+		"module_path": "./prebuild/{node_napi_label}-{platform}-{arch}-{libc}-{libc_version}/",
 		"remote_path": "v{version}",
-		"package_name": "{module_name}-v{version}-{node_abi}-napi-v{napi_build_version}-{platform}-{arch}-{libc}-{libc_version}.tar.gz",
+		"package_name": "{module_name}-v{version}-{node_napi_label}-{platform}-{arch}-{libc}-{libc_version}.tar.gz",
 		"host": "https://github.com/discordjs/opus/releases/download/",
 		"napi_versions": [
 			3

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"build": "bun x node-pre-gyp install build package || node-pre-gyp install build package",
 		"lint": "prettier --check . && eslint lib --format=pretty",
 		"lint:fix": "prettier --write . && eslint lib --fix --format=pretty",
-		"test": "bun tests/test.js || node tests/test.js"
+		"test": "node tests/test.js",
+		"test:bun": "bun tests/test.js"
 	},
 	"keywords": [
 		"native",


### PR DESCRIPTION
## Summary
- add Bun CI jobs to build/test on Ubuntu
- allow Bun installs/tests via scripts and N-API prebuild naming
- document Bun install/test workflow

## Testing
- bun install --ignore-scripts && bun run install && bun run test