### PR TITLE
Support fec and plc

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -35,13 +35,24 @@ const { OpusEncoder } = require('../lib/index.js');
 {
   const opus = new OpusEncoder(16_000, 1);
 
-  // Decode with null for packet loss concealment
+  // Decode with null for packet loss concealment (using default MAX_FRAME_SIZE)
   const plcFrame = opus.decode(null);
   assert(plcFrame.length > 0, 'PLC frame should have length > 0');
 
-  // Decode with undefined for packet loss concealment
+  // Decode with undefined for packet loss concealment (using default MAX_FRAME_SIZE)
   const plcFrame2 = opus.decode(undefined);
   assert(plcFrame2.length > 0, 'PLC frame should have length > 0');
+
+  // Decode with null and specific frame_size for proper PLC
+  // For 16kHz, 20ms = 320 samples, so we expect 320 * 2 bytes = 640 bytes output
+  const plcFrame3 = opus.decode(null, 0, 320);
+  assert(plcFrame3.length === 640, `PLC frame with frame_size=320 should be 640 bytes, got ${plcFrame3.length}`);
+
+  // Test with 48kHz decoder
+  const opus48 = new OpusEncoder(48_000, 2);
+  // For 48kHz stereo, 20ms = 960 samples per channel, output is 960 * 2 channels * 2 bytes = 3840 bytes
+  const plcFrame48 = opus48.decode(null, 0, 960);
+  assert(plcFrame48.length === 3840, `PLC frame for 48kHz stereo with frame_size=960 should be 3840 bytes, got ${plcFrame48.length}`);
 }
 
 // Forward error correction (FEC) parameter

--- a/tests/test.js
+++ b/tests/test.js
@@ -31,4 +31,38 @@ const { OpusEncoder } = require('../lib/index.js');
   assert.throws(() => new OpusEncoder(16000, null), /Expected channels to be a number/);
 }
 
+// Packet loss concealment (PLC) with null/undefined
+{
+  const opus = new OpusEncoder(16_000, 1);
+
+  // Decode with null for packet loss concealment
+  const plcFrame = opus.decode(null);
+  assert(plcFrame.length > 0, 'PLC frame should have length > 0');
+
+  // Decode with undefined for packet loss concealment
+  const plcFrame2 = opus.decode(undefined);
+  assert(plcFrame2.length > 0, 'PLC frame should have length > 0');
+}
+
+// Forward error correction (FEC) parameter
+{
+  const opus = new OpusEncoder(16_000, 1);
+  const frame = fs.readFileSync(path.join(__dirname, 'frame.opus'));
+
+  // Decode with decode_fec = 0 (default)
+  const decoded1 = opus.decode(frame, 0);
+  assert(decoded1.length === 640, 'Decoded frame length is not 640');
+
+  // Decode with decode_fec = 1
+  const decoded2 = opus.decode(frame, 1);
+  assert(decoded2.length === 640, 'Decoded frame length is not 640');
+
+  // Decode with decode_fec as boolean
+  const decoded3 = opus.decode(frame, false);
+  assert(decoded3.length === 640, 'Decoded frame length is not 640');
+
+  const decoded4 = opus.decode(frame, true);
+  assert(decoded4.length === 640, 'Decoded frame length is not 640');
+}
+
 console.log('Passed');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,8 +6,9 @@ declare module '@discordjs/opus' {
 		 * Decodes the given Opus buffer to PCM signed 16-bit little-endian
 		 * @param buf Opus buffer, or null/undefined for packet loss concealment (PLC)
 		 * @param decode_fec Optional flag to enable forward error correction (0 or 1, default 0)
+		 * @param frame_size Optional number of samples per channel to decode. For PLC or FEC, this must be exactly the duration of the missing audio (e.g., 960 for 20ms at 48kHz). Defaults to maximum frame size for normal decoding.
 		 */
-		public decode(buf: Buffer | null | undefined, decode_fec?: number | boolean): Buffer;
+		public decode(buf: Buffer | null | undefined, decode_fec?: number | boolean, frame_size?: number): Buffer;
 		public applyEncoderCTL(ctl: number, value: number): void;
 		public applyDecoderCTL(ctl: number, value: number): void;
 		public setBitrate(bitrate: number): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,9 +4,10 @@ declare module '@discordjs/opus' {
 		public encode(buf: Buffer): Buffer;
 		/**
 		 * Decodes the given Opus buffer to PCM signed 16-bit little-endian
-		 * @param buf Opus buffer
+		 * @param buf Opus buffer, or null/undefined for packet loss concealment (PLC)
+		 * @param decode_fec Optional flag to enable forward error correction (0 or 1, default 0)
 		 */
-		public decode(buf: Buffer): Buffer;
+		public decode(buf: Buffer | null | undefined, decode_fec?: number | boolean): Buffer;
 		public applyEncoderCTL(ctl: number, value: number): void;
 		public applyDecoderCTL(ctl: number, value: number): void;
 		public setBitrate(bitrate: number): void;


### PR DESCRIPTION
## Description

This code exposes Opus's FEC and PLC support in discord/opus.

If the Opus data being decoded passed over an unreliable channel (e.g. WebRTC) at some point, packets may be missing.  FEC and PLC allow missing audio to be interpolated.

This code has been written to be backward-compatible, so existing usages won't need to change.

- [x] Code changes have been tested, or there are no code changes
