### PR TITLE
Expose opus_decode's support for FEC and PLC through a new JS conceal method.

### DIFF
--- a/src/node-opus.h
+++ b/src/node-opus.h
@@ -32,7 +32,9 @@ class NodeOpusEncoder : public ObjectWrap<NodeOpusEncoder> {
 		Napi::Value Encode(const CallbackInfo& args);
 		
 		Napi::Value Decode(const CallbackInfo& args);
-		
+
+		Napi::Value Conceal(const CallbackInfo& args);
+
 		void ApplyEncoderCTL(const CallbackInfo& args);
 		
 		void ApplyDecoderCTL(const CallbackInfo& args);

--- a/tests/test.js
+++ b/tests/test.js
@@ -31,4 +31,38 @@ const { OpusEncoder } = require('../lib/index.js');
   assert.throws(() => new OpusEncoder(16000, null), /Expected channels to be a number/);
 }
 
+// Packet loss concealment (PLC) with conceal method
+{
+  const opus = new OpusEncoder(16_000, 1);
+
+  // Conceal with specific frame_size for proper PLC
+  // For 16kHz, 20ms = 320 samples, so we expect 320 * 2 bytes = 640 bytes output
+  const plcFrame = opus.conceal(320);
+  assert(plcFrame.length === 640, `PLC frame with frame_size=320 should be 640 bytes, got ${plcFrame.length}`);
+
+  // Test with 48kHz decoder
+  const opus48 = new OpusEncoder(48_000, 2);
+  // For 48kHz stereo, 20ms = 960 samples per channel, output is 960 * 2 channels * 2 bytes = 3840 bytes
+  const plcFrame48 = opus48.conceal(960);
+  assert(plcFrame48.length === 3840, `PLC frame for 48kHz stereo with frame_size=960 should be 3840 bytes, got ${plcFrame48.length}`);
+}
+
+// Forward error correction (FEC) with conceal method
+{
+  const opus = new OpusEncoder(16_000, 1);
+  const frame = fs.readFileSync(path.join(__dirname, 'frame.opus'));
+
+  // Conceal with FEC using a packet (frame_size=320 for 20ms at 16kHz)
+  const decoded1 = opus.conceal(320, frame);
+  assert(decoded1.length === 640, 'FEC decoded frame length is not 640');
+
+  // Conceal without packet (PLC only)
+  const decoded2 = opus.conceal(320);
+  assert(decoded2.length === 640, 'PLC decoded frame length is not 640');
+
+  // Conceal with null packet (PLC)
+  const decoded3 = opus.conceal(320, null);
+  assert(decoded3.length === 640, 'PLC decoded frame length is not 640');
+}
+
 console.log('Passed');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,6 +7,12 @@ declare module '@discordjs/opus' {
 		 * @param buf Opus buffer
 		 */
 		public decode(buf: Buffer): Buffer;
+		/**
+		 * Performs packet loss concealment (PLC) or forward error correction (FEC)
+		 * @param frame_size Number of samples per channel to generate. This must be exactly the duration of the missing audio (e.g., 960 for 20ms at 48kHz, 320 for 20ms at 16kHz).
+		 * @param packet Optional Opus packet buffer for FEC. If provided, FEC will be used to reconstruct the audio. If omitted, null, or undefined, PLC will generate synthetic audio.
+		 */
+		public conceal(frame_size: number, packet?: Buffer | null): Buffer;
 		public applyEncoderCTL(ctl: number, value: number): void;
 		public applyDecoderCTL(ctl: number, value: number): void;
 		public setBitrate(bitrate: number): void;


### PR DESCRIPTION
## Description

This code exposes Opus's FEC and PLC support in discord/opus.

If the Opus data being decoded passed over an unreliable channel (e.g. WebRTC) at some point, packets may be missing. FEC and PLC allow missing audio to be interpolated.

This code has been written to be backward-compatible, so existing usages won't need to change.

This is a different API approach than https://github.com/discordjs/opus/pull/195 to implement the feature request in https://github.com/discordjs/opus/issues/196.  It separates the loss concealment functionality into a new API, which should be somewhat less confusing and harder to mis-use than the approach in https://github.com/discordjs/opus/pull/195.

<!-- Please describe the changes this pull request makes and why it should be merged. -->

- [x] Code changes have been tested, or there are no code changes
