### PR TITLE
ci: add glibc 2.41 prebuilds for Debian 13/Raspberry Pi OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,42 @@ jobs:
 
       - name: Stop container
         run: docker rm -f runner
+
+  build_glibc_241:
+    name: Build node ${{ matrix.node }} on ${{ matrix.arch }} (glibc 2.41)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            node: 22
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            node: 22
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup container
+        run: |
+          docker run --name runner --rm -it -d -v $PWD:/node-opus -w /node-opus debian:trixie
+
+      - name: Setup env with Node v${{ matrix.node }}
+        run: |
+          docker exec runner apt-get update
+          docker exec runner apt-get install -y curl build-essential python3 git ca-certificates
+          docker exec runner bash -c "curl -fsSL https://deb.nodesource.com/setup_${{ matrix.node }}.x | bash -"
+          docker exec runner apt-get install -y nodejs
+
+      - name: Install dependencies
+        run: docker exec runner npm install --build-from-source
+
+      - name: Package prebuild
+        run: docker exec runner npm run build
+
+      - name: Stop container
+        run: docker rm -f runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,70 @@ jobs:
         with:
           path: 'build/stage/**/*.tar.gz'
 
+  build_glibc_241:
+    name: Prebuild node ${{ matrix.node }} on ${{ matrix.arch }} (glibc 2.41)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            node: 20
+          - os: ubuntu-latest
+            arch: x64
+            node: 22
+          - os: ubuntu-latest
+            arch: x64
+            node: 24
+          - os: ubuntu-latest
+            arch: x64
+            node: 25
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            node: 20
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            node: 22
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            node: 24
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            node: 25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup container
+        run: |
+          docker run --name runner --rm -it -d -v $PWD:/node-opus -w /node-opus debian:trixie
+
+      - name: Setup env with Node v${{ matrix.node }}
+        run: |
+          docker exec runner apt-get update
+          docker exec runner apt-get install -y curl build-essential python3 git ca-certificates
+          docker exec runner bash -c "curl -fsSL https://deb.nodesource.com/setup_${{ matrix.node }}.x | bash -"
+          docker exec runner apt-get install -y nodejs
+
+      - name: Install dependencies
+        run: docker exec runner npm install --build-from-source
+
+      - name: Package prebuild
+        run: docker exec runner npm run build
+
+      - name: Stop container
+        run: docker rm -f runner
+
+      - name: Upload prebuild asset
+        uses: icrawl/action-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: 'build/stage/**/*.tar.gz'
+
   build_musl:
     name: Prebuild node ${{ matrix.node }} on ${{ matrix.os }} (musl)
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Adds CI jobs to build prebuilt binaries for glibc 2.41 (Debian Trixie) systems.

## Problem

Currently, `@discordjs/opus` prebuilt binaries are only available for:
- glibc 2.31 (Ubuntu 20.04)
- glibc 2.35 (Ubuntu 22.04)
- glibc 2.39 (Ubuntu 24.04)

Users on Debian 13 (Trixie) and Raspberry Pi OS Trixie get glibc 2.41, which has no prebuilt binary. This causes npm install to:
1. Try to download the missing `glibc-2.41` prebuilt
2. Fall back to compiling from source
3. The compilation also fails due to newer GCC warnings being treated as errors

## Solution

Add a new `build_glibc_241` job that uses `debian:trixie` Docker containers to build prebuilts for glibc 2.41 systems.

This covers:
- Debian 13 (Trixie)
- Raspberry Pi OS Trixie (RPi 5 default OS)
- Future Ubuntu releases

## Changes

- **release.yml**: Add `build_glibc_241` job for x64 and arm64 builds with Node 20, 22, 24, 25
- **build.yml**: Add `build_glibc_241` job (limited to Node 22 for PR testing)

## Testing

I verified the build works on a Raspberry Pi 5 running Debian Trixie:
```
$ npm install --build-from-source
$ npm test
> @discordjs/opus@0.10.0 test
> node tests/test.js
Passed
```

The produced binary is correctly named:
`opus-v0.10.0-node-v127-napi-v3-linux-arm64-glibc-2.41.tar.gz`