### PR TITLE
fix: use array delete operator to delete array, this was causing a crash in node 24

### DIFF
--- a/src/node-opus.cc
+++ b/src/node-opus.cc
@@ -76,7 +76,7 @@ NodeOpusEncoder::~NodeOpusEncoder() {
 	this->encoder = nullptr;
 	this->decoder = nullptr;
 
-	if (this->outPcm) delete this->outPcm;
+	if (this->outPcm) delete[] this->outPcm;
 	this->outPcm = nullptr;
 }
 


### PR DESCRIPTION
## Description

Testing this node add-on in node 24 Debian bookworm.
This node-addon is causing a SIGSEGV

Steps:
Create multiple (~10-15) OpusEncoders.
Call .decode on them
Release the encoders so that they are deleted.

The next OpusEncoder.decode causes a SIGSEGV.

Fix:
this->outPcm is allocated as an array, but delete was called without the array operator. Adding the array operator fixed the crash.